### PR TITLE
Set up CI for the repository

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -1,0 +1,11 @@
+---
+
+- meta:
+    cluster: devops-ci
+
+- job:
+    node: "linux && immutable"
+
+    wrappers:
+      - ansicolor
+      - timestamps

--- a/.ci/jobs/ent-search-connector-microsoft-teams.yml
+++ b/.ci/jobs/ent-search-connector-microsoft-teams.yml
@@ -1,0 +1,33 @@
+---
+
+- job:
+    name: ent-search-ingestion/microsoft-teams-connector
+    description: "Runs tests and linters against the repository."
+    project-type: multibranch
+    node: master
+    concurrent: true
+    script-path: .ci/pipelines/ent-search-connector-microsoft-teams.groovy
+    prune-dead-branches: true
+    scm:
+      - github:
+          repo: enterprise-search-microsoft-teams-connector
+          repo-owner: elastic
+          disable-pr-notifications: true
+          branch-discovery: all
+          discover-pr-origin: current
+          discover-pr-forks-strategy: false
+          discover-pr-forks-trust: nobody
+          discover-tags: false
+          build-strategies:
+            - regular-branches: true
+          property-strategies:
+            all-branches:
+              - pipeline-branch-durability-override: performance-optimized
+          credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+          ssh-checkout:
+            credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+          clean:
+            after: true
+            before: true
+          prune: true
+          timeout: 10

--- a/.ci/pipelines/ent-search-connector-microsoft-teams.groovy
+++ b/.ci/pipelines/ent-search-connector-microsoft-teams.groovy
@@ -1,0 +1,43 @@
+//
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+//
+
+// Loading the shared lib
+@Library(['apm', 'estc', 'entsearch']) _
+
+eshPipeline(
+    timeout: 45,
+    project_name: 'Enterprise Search Microsoft Teams Connector',
+    repository: 'enterprise-search-microsoft-teams-connector',
+    stages: [
+        [
+            name: 'Linting',
+            type: 'script',
+            label: 'Makefile',
+            script: {
+                sh 'docker run -v `pwd`:/ci -w=/ci --rm --name jenkins-linter -v "$PWD":/usr/src/myapp -w /usr/src/myapp python:3 make lint'
+            },
+            match_on_all_branches: true,
+        ],
+        [
+            name: 'Testing',
+            type: 'script',
+            label: 'Makefile',
+            script: {
+                sh 'docker run -v `pwd`:/ci -w=/ci --rm --name jenkins-tester -v "$PWD":/usr/src/myapp -w /usr/src/myapp python:3 make test'
+            },
+            match_on_all_branches: true,
+        ],
+        [
+            name: 'Test Coverage',
+            type: 'script',
+            label: 'Makefile',
+            script: {
+                sh 'docker run -v `pwd`:/ci -w=/ci --rm --name jenkins-tester -v "$PWD":/usr/src/myapp -w /usr/src/myapp python:3 make cover'
+            },
+            match_on_all_branches: true,
+        ]
+    ]
+)


### PR DESCRIPTION
Subj.

Set up CI for the repository same way it's set up for https://github.com/elastic/enterprise-search-sharepoint-server-2016-connector repository.