### PR TITLE
Changes to the configuration fields

### DIFF
--- a/ees_microsoft_teams/schema.py
+++ b/ees_microsoft_teams/schema.py
@@ -185,7 +185,7 @@ schema = {
         'required': False,
         'type': 'string',
         'default': 'INFO',
-        'allowed': ['DEBUG', 'INFO', 'WARNING', 'ERROR '],
+        'allowed': ['DEBUG', 'INFO', 'WARNING', 'ERROR'],
         'empty': False
     },
     'retry_count': {
@@ -198,10 +198,16 @@ schema = {
         'required': False,
         'type': 'string'
     },
-    'max_threads': {
+    'ms_teams_sync_thread_count': {
         'required': False,
         'type': 'integer',
-        'default': 40,
+        'default': 5,
+        'min': 1
+    },
+    'enterprise_search_sync_thread_count': {
+        'required': False,
+        'type': 'integer',
+        'default': 5,
         'min': 1
     }
 }

--- a/microsoft_teams_connector.yml
+++ b/microsoft_teams_connector.yml
@@ -43,7 +43,9 @@ end_time:
 log_level: INFO
 #The number of retries to perform in case of server error. The connector will use exponential back-off for retry mechanism
 retry_count: 3
-#Number of threads to be used in multithreading for the connector.
-max_threads: 40
+#Number of threads to be used in multi-threading for the microsoft teams sync.
+ms_teams_sync_thread_count: 5
+#Number of threads to be used in multi-threading for the enterprise search sync.
+enterprise_search_sync_thread_count: 5
 #The path of csv file containing mapping of Microsoft Teams user ID to Workplace user ID
 microsoft_teams.user_mapping: ""

--- a/tests/config/microsoft_teams_connector.yml
+++ b/tests/config/microsoft_teams_connector.yml
@@ -43,7 +43,9 @@ end_time:
 log_level: INFO
 #The number of retries to perform in case of server error. The connector will use exponential back-off for retry mechanism
 retry_count: 3
-#Number of threads to be used in multithreading for the connector.
-max_threads: 40
+#Number of threads to be used in multi-threading for the microsoft teams sync.
+ms_teams_sync_thread_count: 5
+#Number of threads to be used in multi-threading for the enterprise search sync.
+enterprise_search_sync_thread_count: 5
 #The path of csv file containing mapping of Microsoft Teams user ID to Workplace user ID
 microsoft_teams.user_mapping: "user_mapping.csv"


### PR DESCRIPTION
Added the following new fields to the configuration along with a validation schema:

- `ms_teams_sync_thread_count`: Number of threads to be used in multithreading while syncing/fetching from Microsoft Teams
- `enterprise_search_sync_thread_count`: Number of threads to be used in multithreading while pushing to the Enterprise Search

Also fixed a trailing space in the schema.py file